### PR TITLE
include dev dependencies for timdex

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,16 +1,6 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
-gem "lita"
-
-# Uncomment to use the HipChat adapter
-# gem "lita-hipchat"
-
-# Uncomment to use the IRC adapter
-# gem "lita-irc"
-
-# Add handlers to give Lita new functionality.
-# For example:
-# gem "lita-google-images"
-# gem "lita-karma"
-
+gem 'dotenv'
+gem 'jwt'
+gem 'lita'
 gem 'lita-timdex', git: 'https://github.com/MITLibraries/lita-timdex'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,6 +10,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     concurrent-ruby (1.1.5)
+    dotenv (2.7.2)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     http_router (0.11.2)
@@ -18,6 +19,7 @@ GEM
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
+    jwt (2.1.0)
     lita (4.7.1)
       bundler (>= 1.3)
       faraday (>= 0.8.7)
@@ -48,6 +50,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  dotenv
+  jwt
   lita
   lita-timdex!
 


### PR DESCRIPTION
This should be addressed in timdex_ruby, but for now just include the dev dependencies for that gem manually so it works.